### PR TITLE
Add Jalali formatting for FullCalendar moment plugin and alarms

### DIFF
--- a/src/filters/dateFormat.js
+++ b/src/filters/dateFormat.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import moment from '@nextcloud/moment'
+import { formatJalaliDate, isPersianLocale } from '@/utils/jalali.js'
 
 /**
  * Formats a date object
@@ -13,9 +14,13 @@ import moment from '@nextcloud/moment'
  * @return {string}
  */
 export default (value, isAllDay, locale) => {
-	if (isAllDay) {
-		return moment(value).locale(locale).format('ll')
-	} else {
-		return moment(value).locale(locale).format('lll')
-	}
+        if (isPersianLocale(locale)) {
+                return formatJalaliDate(value, { includeTime: !isAllDay })
+        }
+
+        if (isAllDay) {
+                return moment(value).locale(locale).format('ll')
+        } else {
+                return moment(value).locale(locale).format('lll')
+        }
 }

--- a/src/filters/dateRangeFormat.js
+++ b/src/filters/dateRangeFormat.js
@@ -4,6 +4,14 @@
  */
 import moment from '@nextcloud/moment'
 import { translate as t } from '@nextcloud/l10n'
+import {
+        formatJalaliDate,
+        formatJalaliMonthYear,
+        formatJalaliNumber,
+        formatJalaliYear,
+        getJalaliWeekInfo,
+        isPersianLocale,
+} from '@/utils/jalali.js'
 
 /**
  * Formats a date-range depending on the user's current view
@@ -14,9 +22,37 @@ import { translate as t } from '@nextcloud/l10n'
  * @return {string}
  */
 export default (value, view, locale) => {
-	switch (view) {
-	case 'timeGridDay':
-		return moment(value).locale(locale).format('ll')
+        if (isPersianLocale(locale)) {
+                switch (view) {
+                case 'timeGridDay':
+                        return formatJalaliDate(value)
+
+                case 'timeGridWeek': {
+                        const { week, year } = getJalaliWeekInfo(value)
+
+                        if (Number.isNaN(week) || Number.isNaN(year)) {
+                                break
+                        }
+
+                        return t('calendar', 'Week {number} of {year}', {
+                                number: formatJalaliNumber(week),
+                                year: formatJalaliNumber(year),
+                        })
+                }
+
+                case 'multiMonthYear':
+                        return formatJalaliYear(value)
+
+                case 'dayGridMonth':
+                case 'listMonth':
+                default:
+                        return formatJalaliMonthYear(value)
+                }
+        }
+
+        switch (view) {
+        case 'timeGridDay':
+                return moment(value).locale(locale).format('ll')
 
 	case 'timeGridWeek':
 		return t('calendar', 'Week {number} of {year}', {

--- a/src/fullcalendar/localization/momentPlugin.js
+++ b/src/fullcalendar/localization/momentPlugin.js
@@ -5,6 +5,14 @@
 import moment from '@nextcloud/moment'
 import { createPlugin } from '@fullcalendar/core'
 import useSettingsStore from '../../store/settings.js'
+import {
+        formatJalaliDate,
+        formatJalaliDateNumeric,
+        formatJalaliDateShort,
+        formatJalaliTime,
+        formatJalaliWeekday,
+        isPersianLocale,
+} from '@/utils/jalali.js'
 
 /**
  * Creates a new moment object using the locale from the global Pinia store
@@ -13,9 +21,132 @@ import useSettingsStore from '../../store/settings.js'
  * @param {number[]} data.array Input data to initialize moment
  * @return {moment.Moment}
  */
-const momentFactory = ({ array }) => {
-	const settingsStore = useSettingsStore()
-	return moment(array).locale(settingsStore.momentLocale)
+const momentFactory = ({ array }, locale) => {
+        return moment(array).locale(locale)
+}
+
+function getDateFromArgPart(part) {
+        if (!part) {
+                return null
+        }
+
+        if (part.marker instanceof Date) {
+                return new Date(part.marker.getTime())
+        }
+
+        if (part.date instanceof Date) {
+                return new Date(part.date.getTime())
+        }
+
+        if (Array.isArray(part.array)) {
+                const [
+                        year,
+                        month = 0,
+                        day = 1,
+                        hour = 0,
+                        minute = 0,
+                        second = 0,
+                        millisecond = 0,
+                ] = part.array
+
+                const date = new Date(year, month, day, hour, minute, second, millisecond)
+
+                if (Number.isNaN(date.getTime())) {
+                        return null
+                }
+
+                return date
+        }
+
+        return null
+}
+
+function formatPersianToken(cmdStr, date) {
+        switch (cmdStr) {
+        case 'LT':
+                return formatJalaliTime(date)
+        case 'll':
+                return formatJalaliDateShort(date)
+        case 'l':
+        case 'L':
+                return formatJalaliDateNumeric(date)
+        case 'LL':
+                return formatJalaliDate(date)
+        case 'ddd':
+                return formatJalaliWeekday(date, { width: 'short' })
+        case 'dddd':
+                return formatJalaliWeekday(date, { width: 'long' })
+        default:
+                return null
+        }
+}
+
+function formatPersianSingle(cmdStr, date) {
+        if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+                return null
+        }
+
+        if (cmdStr === 'ddd l') {
+                const weekday = formatJalaliWeekday(date, { width: 'short' })
+                const numeric = formatJalaliDateNumeric(date)
+
+                if (!weekday || !numeric) {
+                        return null
+                }
+
+                return `${weekday} ${numeric}`
+        }
+
+        if (cmdStr === 'LL, dddd') {
+                const longDate = formatJalaliDate(date)
+                const weekday = formatJalaliWeekday(date, { width: 'long' })
+
+                if (longDate && weekday) {
+                        return `${longDate}، ${weekday}`
+                }
+
+                return longDate || weekday || null
+        }
+
+        return formatPersianToken(cmdStr, date)
+}
+
+function formatPersianRange(cmdStr, arg) {
+        const startDate = getDateFromArgPart(arg.start)
+
+        if (!startDate) {
+                return null
+        }
+
+        const formattedStart = formatPersianSingle(cmdStr, startDate)
+
+        if (formattedStart === null) {
+                return null
+        }
+
+        if (!arg.end) {
+                return formattedStart
+        }
+
+        const endDate = getDateFromArgPart(arg.end)
+
+        if (!endDate) {
+                return formattedStart
+        }
+
+        const formattedEnd = formatPersianSingle(cmdStr, endDate)
+
+        if (formattedEnd === null) {
+                return null
+        }
+
+        if (formattedStart === formattedEnd) {
+                return formattedStart
+        }
+
+        const separator = typeof arg.defaultSeparator === 'string' ? arg.defaultSeparator : ' – '
+
+        return `${formattedStart}${separator}${formattedEnd}`
 }
 
 /**
@@ -26,31 +157,44 @@ const momentFactory = ({ array }) => {
  * @return {function(string, string):string} cmdFormatter function
  */
 const cmdFormatter = (cmdStr, arg) => {
-	// With our specific DateFormattingConfig,
-	// cmdStr will always be a moment parsable string
-	// like LT, etc.
-	//
-	// No need to manually parse it.
-	//
-	// This is not the case, if you use the standard FC
-	// formatting config.
+        // With our specific DateFormattingConfig,
+        // cmdStr will always be a moment parsable string
+        // like LT, etc.
+        //
+        // No need to manually parse it.
+        //
+        // This is not the case, if you use the standard FC
+        // formatting config.
 
-	// If arg.end is defined, this is a time-range
-	if (arg.end) {
-		const start = momentFactory(arg.start).format(cmdStr)
-		const end = momentFactory(arg.end).format(cmdStr)
+        const settingsStore = useSettingsStore()
+        const locale = settingsStore.momentLocale
 
-		if (start === end) {
-			return start
-		}
+        if (isPersianLocale(locale)) {
+                const persianFormatted = formatPersianRange(cmdStr, arg)
 
-		return start + arg.defaultSeparator + end
-	}
+                if (typeof persianFormatted === 'string') {
+                        return persianFormatted
+                }
+        }
 
-	return momentFactory(arg.start).format(cmdStr)
+        // If arg.end is defined, this is a time-range
+        if (arg.end) {
+                const start = momentFactory(arg.start, locale).format(cmdStr)
+                const end = momentFactory(arg.end, locale).format(cmdStr)
+
+                if (start === end) {
+                        return start
+                }
+
+                return start + arg.defaultSeparator + end
+        }
+
+        return momentFactory(arg.start, locale).format(cmdStr)
 }
 
 export default createPlugin({
-	name: '@nextcloud/moment-plugin',
-	cmdFormatter,
+        name: '@nextcloud/moment-plugin',
+        cmdFormatter,
 })
+
+export { cmdFormatter }

--- a/src/utils/jalali.js
+++ b/src/utils/jalali.js
@@ -1,0 +1,263 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+const PERSIAN_UNICODE_EXTENSION = 'u-ca-persian'
+const DEFAULT_PERSIAN_LOCALE = 'fa-IR'
+const DEFAULT_PERSIAN_CALENDAR_LOCALE = `${DEFAULT_PERSIAN_LOCALE}-${PERSIAN_UNICODE_EXTENSION}`
+const DEFAULT_PERSIAN_LATIN_CALENDAR_LOCALE = `${DEFAULT_PERSIAN_LOCALE}-${PERSIAN_UNICODE_EXTENSION}-nu-latn`
+
+const JALALI_MONTH_OFFSETS = [
+0,
+31,
+62,
+93,
+124,
+155,
+186,
+216,
+246,
+276,
+306,
+336,
+]
+
+let cachedPersianLatnFormatter = null
+
+/**
+ * Normalizes locale identifiers for easier comparison.
+ *
+ * @param {string} locale
+ * @return {string}
+ */
+function normalizeLocale(locale) {
+        return locale
+                .replace(/_/g, '-')
+                .toLowerCase()
+                .trim()
+}
+
+/**
+ * Checks whether a locale should use the Jalali (Persian) calendar.
+ *
+ * @param {string | undefined | null} locale
+ * @return {boolean}
+ */
+export function isPersianLocale(locale) {
+        if (!locale) {
+                return false
+        }
+
+        const normalized = normalizeLocale(String(locale))
+
+        if (normalized === 'fa') {
+                return true
+        }
+
+        if (normalized.startsWith('fa-')) {
+                return true
+        }
+
+        return normalized.includes(PERSIAN_UNICODE_EXTENSION)
+}
+
+/**
+ * Formats a date with the Persian (Jalali) calendar.
+ *
+ * @param {Date | string | number} value Date value to format
+ * @param {object} [options]
+ * @param {boolean} [options.includeTime=false] Whether the time portion should be included
+ * @return {string}
+ */
+function ensureDate(value) {
+        if (value instanceof Date) {
+                return Number.isNaN(value.getTime()) ? null : value
+        }
+
+        const date = new Date(value)
+
+        return Number.isNaN(date.getTime()) ? null : date
+}
+
+function formatWithIntl(value, options) {
+        const date = ensureDate(value)
+
+        if (!date) {
+                return ''
+        }
+
+        try {
+                return new Intl.DateTimeFormat(DEFAULT_PERSIAN_CALENDAR_LOCALE, options).format(date)
+        } catch (error) {
+                return date.toLocaleString(DEFAULT_PERSIAN_LOCALE, options)
+        }
+}
+
+export function formatJalaliDate(value, { includeTime = false } = {}) {
+        const baseOptions = {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+        }
+
+        if (includeTime) {
+                Object.assign(baseOptions, {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                        hourCycle: 'h23',
+                })
+        }
+
+return formatWithIntl(value, baseOptions)
+}
+
+export function formatJalaliMonthYear(value) {
+        return formatWithIntl(value, {
+                year: 'numeric',
+                month: 'long',
+        })
+}
+
+export function formatJalaliYear(value) {
+        return formatWithIntl(value, {
+                year: 'numeric',
+        })
+}
+
+export function formatJalaliDateNumeric(value) {
+        return formatWithIntl(value, {
+                year: 'numeric',
+                month: 'numeric',
+                day: 'numeric',
+        })
+}
+
+export function formatJalaliDateShort(value) {
+        return formatWithIntl(value, {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+        })
+}
+
+export function formatJalaliTime(value) {
+        return formatWithIntl(value, {
+                hour: '2-digit',
+                minute: '2-digit',
+                hourCycle: 'h23',
+        })
+}
+
+export function formatJalaliWeekday(value, { width = 'long' } = {}) {
+        const validWidths = new Set(['long', 'short', 'narrow'])
+        const normalizedWidth = validWidths.has(width) ? width : 'long'
+
+        return formatWithIntl(value, {
+                weekday: normalizedWidth,
+        })
+}
+
+function getPersianLatnFormatter() {
+        if (cachedPersianLatnFormatter !== null) {
+                return cachedPersianLatnFormatter
+        }
+
+        try {
+                cachedPersianLatnFormatter = new Intl.DateTimeFormat(DEFAULT_PERSIAN_LATIN_CALENDAR_LOCALE, {
+                        year: 'numeric',
+                        month: 'numeric',
+                        day: 'numeric',
+                })
+        } catch (error) {
+                cachedPersianLatnFormatter = undefined
+        }
+
+        return cachedPersianLatnFormatter
+}
+
+function getJalaliParts(date) {
+        const formatter = getPersianLatnFormatter()
+
+        if (!formatter || typeof formatter.formatToParts !== 'function') {
+                return null
+        }
+
+        const parts = formatter.formatToParts(date)
+
+        const year = Number.parseInt(parts.find((part) => part.type === 'year')?.value ?? '', 10)
+        const month = Number.parseInt(parts.find((part) => part.type === 'month')?.value ?? '', 10)
+        const day = Number.parseInt(parts.find((part) => part.type === 'day')?.value ?? '', 10)
+
+        if ([year, month, day].some(Number.isNaN)) {
+                return null
+        }
+
+        return {
+                year,
+                month,
+                day,
+        }
+}
+
+function getJalaliDayOfYear(month, day) {
+        if (month < 1 || month > 12) {
+                return NaN
+        }
+
+        const offset = JALALI_MONTH_OFFSETS[month - 1]
+
+        if (typeof offset !== 'number') {
+                return NaN
+        }
+
+        return offset + day
+}
+
+export function getJalaliWeekInfo(value) {
+        const date = ensureDate(value)
+
+        if (!date) {
+                return {
+                        year: NaN,
+                        week: NaN,
+                }
+        }
+
+        const parts = getJalaliParts(date)
+
+        if (!parts) {
+                return {
+                        year: NaN,
+                        week: NaN,
+                }
+        }
+
+        const dayOfYear = getJalaliDayOfYear(parts.month, parts.day)
+
+        if (Number.isNaN(dayOfYear)) {
+                return {
+                        year: NaN,
+                        week: NaN,
+                }
+        }
+
+        const week = Math.max(1, Math.ceil(dayOfYear / 7))
+
+        return {
+                year: parts.year,
+                week,
+        }
+}
+
+export function formatJalaliNumber(value) {
+        if (typeof value !== 'number' || Number.isNaN(value)) {
+                return ''
+        }
+
+        try {
+                return new Intl.NumberFormat(DEFAULT_PERSIAN_LOCALE).format(value)
+        } catch (error) {
+                return String(value)
+        }
+}

--- a/tests/javascript/unit/filters/__snapshots__/dateFormat.test.js.snap
+++ b/tests/javascript/unit/filters/__snapshots__/dateFormat.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
 
 exports[`format/dateFormat test suite should format a timed date 1`] = `"1. Jan. 2019 00:00"`;
 
+exports[`format/dateFormat test suite should format a timed date in Persian locale 1`] = `"۱ فروردین ۱۳۹۸ ساعت ۱۸:۳۰"`;
+
 exports[`format/dateFormat test suite should format an all-day date 1`] = `"1. Jan. 2019"`;
+
+exports[`format/dateFormat test suite should format an all-day date in Persian locale 1`] = `"۱ فروردین ۱۳۹۸"`;

--- a/tests/javascript/unit/filters/__snapshots__/dateRangeFormat.test.js.snap
+++ b/tests/javascript/unit/filters/__snapshots__/dateRangeFormat.test.js.snap
@@ -1,11 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-// SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+
+exports[`format/dateRangeFormat test suite should provide Jalali month as fallback for unknown view when locale is Persian 1`] = `"۱۳۹۷ دی"`;
+
+exports[`format/dateRangeFormat test suite should provide a Jalali format for day view when locale is Persian 1`] = `"۱۱ دی ۱۳۹۷"`;
+
+exports[`format/dateRangeFormat test suite should provide a Jalali format for month view when locale is Persian 1`] = `"۱۳۹۷ دی"`;
+
+exports[`format/dateRangeFormat test suite should provide a Jalali format for week view when locale is Persian 1`] = `"Week ۴۱ of ۱٬۳۹۷"`;
 
 exports[`format/dateRangeFormat test suite should provide a format for day view 1`] = `"1. Jan. 2019"`;
 
 exports[`format/dateRangeFormat test suite should provide a format for month view 1`] = `"Januar 2019"`;
 
-exports[`format/dateRangeFormat test suite should provide a format for week view 1`] = `"Week {number} of {year}"`;
+exports[`format/dateRangeFormat test suite should provide a format for week view 1`] = `"Week 1 of 2019"`;
 
 exports[`format/dateRangeFormat test suite should provide month as fallback for unknown view 1`] = `"Januar 2019"`;

--- a/tests/javascript/unit/filters/alarmFormat.test.js
+++ b/tests/javascript/unit/filters/alarmFormat.test.js
@@ -60,9 +60,9 @@ describe('format/alarmFormat test suite', () => {
 		expect(alarmFormat(alarm, true, 'Europe/Berlin', 'de')).toMatchSnapshot()
 	})
 
-	it('should format an alarm for an all-day event weeks weeks before', () => {
-		const alarm = {
-			type: 'EMAIL',
+        it('should format an alarm for an all-day event weeks weeks before', () => {
+                const alarm = {
+                        type: 'EMAIL',
 			isRelative: true,
 			absoluteDate: null,
 			absoluteTimezoneId: null,
@@ -77,8 +77,38 @@ describe('format/alarmFormat test suite', () => {
 			relativeTrigger: -159 * 60 * 60 - 30 * 60,
 		}
 
-		expect(alarmFormat(alarm, true, 'Europe/Berlin', 'de')).toMatchSnapshot()
-	})
+                expect(alarmFormat(alarm, true, 'Europe/Berlin', 'de')).toMatchSnapshot()
+        })
+
+        it('should format a Persian all-day alarm days before with Jalali time', () => {
+                const alarm = {
+                        type: 'EMAIL',
+                        isRelative: true,
+                        absoluteDate: null,
+                        absoluteTimezoneId: null,
+                        relativeIsBefore: true,
+                        relativeIsRelatedToStart: true,
+                        relativeAmountTimed: 0,
+                        relativeUnitTimed: 'minutes',
+                        relativeAmountAllDay: 1,
+                        relativeUnitAllDay: 'days',
+                        relativeHoursAllDay: 9,
+                        relativeMinutesAllDay: 0,
+                        relativeTrigger: -15 * 60 * 60,
+                }
+
+                alarmFormat(alarm, true, 'Asia/Tehran', 'fa')
+
+                expect(translatePlural).toHaveBeenCalledWith(
+                        'calendar',
+                        '%n day before the event at {formattedHourMinute}',
+                        '%n days before the event at {formattedHourMinute}',
+                        alarm.relativeAmountAllDay,
+                        expect.objectContaining({
+                                formattedHourMinute: '۰۹:۰۰',
+                        })
+                )
+        })
 
 	it('should format an alarm for an all-day event on the same day at a certain time', () => {
 		const alarm = {
@@ -261,9 +291,9 @@ describe('format/alarmFormat test suite', () => {
 		expect(alarmFormat(alarm, false, 'Europe/Berlin', 'de')).toEqual('on {time}')
 	})
 
-	it('should format an absolute alarm in a different timezone', () => {
-		const date = new Date(2019, 0, 1, 0, 0, 0, 0)
-		const alarm = {
+        it('should format an absolute alarm in a different timezone', () => {
+                const date = new Date(2019, 0, 1, 0, 0, 0, 0)
+                const alarm = {
 			type: 'EMAIL',
 			isRelative: false,
 			absoluteDate: date,
@@ -279,7 +309,68 @@ describe('format/alarmFormat test suite', () => {
 			relativeTrigger: null,
 		}
 
-		expect(alarmFormat(alarm, true, 'Europe/Berlin', 'de')).toEqual('on {time} ({timezoneId})')
-	})
+                expect(alarmFormat(alarm, true, 'Europe/Berlin', 'de')).toEqual('on {time} ({timezoneId})')
+        })
+
+        it('should format a Persian absolute alarm in the user\'s timezone', () => {
+                const date = new Date(2019, 0, 1, 0, 0, 0, 0)
+                const alarm = {
+                        type: 'EMAIL',
+                        isRelative: false,
+                        absoluteDate: date,
+                        absoluteTimezoneId: 'Asia/Tehran',
+                        relativeIsBefore: null,
+                        relativeIsRelatedToStart: null,
+                        relativeAmountTimed: null,
+                        relativeUnitTimed: null,
+                        relativeAmountAllDay: null,
+                        relativeUnitAllDay: null,
+                        relativeHoursAllDay: null,
+                        relativeMinutesAllDay: null,
+                        relativeTrigger: null,
+                }
+
+                const result = alarmFormat(alarm, false, 'Asia/Tehran', 'fa')
+
+                expect(result).toEqual('on {time}')
+                expect(translate).toHaveBeenCalledWith(
+                        'calendar',
+                        'on {time}',
+                        {
+                                time: 'سه‌شنبه، ۱۱ دی ۱۳۹۷ ساعت ۰۰:۰۰',
+                        }
+                )
+        })
+
+        it('should format a Persian absolute alarm in a different timezone', () => {
+                const date = new Date(2019, 0, 1, 0, 0, 0, 0)
+                const alarm = {
+                        type: 'EMAIL',
+                        isRelative: false,
+                        absoluteDate: date,
+                        absoluteTimezoneId: 'America/New_York',
+                        relativeIsBefore: null,
+                        relativeIsRelatedToStart: null,
+                        relativeAmountTimed: null,
+                        relativeUnitTimed: null,
+                        relativeAmountAllDay: null,
+                        relativeUnitAllDay: null,
+                        relativeHoursAllDay: null,
+                        relativeMinutesAllDay: null,
+                        relativeTrigger: null,
+                }
+
+                const result = alarmFormat(alarm, true, 'Asia/Tehran', 'fa')
+
+                expect(result).toEqual('on {time} ({timezoneId})')
+                expect(translate).toHaveBeenCalledWith(
+                        'calendar',
+                        'on {time} ({timezoneId})',
+                        {
+                                time: 'سه‌شنبه، ۱۱ دی ۱۳۹۷ ساعت ۰۰:۰۰',
+                                timezoneId: 'America/New_York',
+                        }
+                )
+        })
 
 })

--- a/tests/javascript/unit/filters/dateFormat.test.js
+++ b/tests/javascript/unit/filters/dateFormat.test.js
@@ -6,14 +6,24 @@ import dateFormat from "../../../../src/filters/dateFormat.js";
 
 describe('format/dateFormat test suite', () => {
 
-	it('should format an all-day date', () => {
-		const date = new Date(2019, 0, 1, 0, 0, 0, 0)
-		expect(dateFormat(date, true, 'de')).toMatchSnapshot()
-	})
+        it('should format an all-day date', () => {
+                const date = new Date(2019, 0, 1, 0, 0, 0, 0)
+                expect(dateFormat(date, true, 'de')).toMatchSnapshot()
+        })
 
-	it('should format a timed date', () => {
-		const date = new Date(2019, 0, 1, 0, 0, 0, 0)
-		expect(dateFormat(date, false, 'de')).toMatchSnapshot()
-	})
+        it('should format a timed date', () => {
+                const date = new Date(2019, 0, 1, 0, 0, 0, 0)
+                expect(dateFormat(date, false, 'de')).toMatchSnapshot()
+        })
+
+        it('should format an all-day date in Persian locale', () => {
+                const date = new Date(2019, 2, 21, 0, 0, 0, 0)
+                expect(dateFormat(date, true, 'fa')).toMatchSnapshot()
+        })
+
+        it('should format a timed date in Persian locale', () => {
+                const date = new Date(2019, 2, 21, 18, 30, 0, 0)
+                expect(dateFormat(date, false, 'fa')).toMatchSnapshot()
+        })
 
 })

--- a/tests/javascript/unit/filters/dateRangeFormat.test.js
+++ b/tests/javascript/unit/filters/dateRangeFormat.test.js
@@ -10,32 +10,55 @@ jest.mock('@nextcloud/l10n')
 
 describe('format/dateRangeFormat test suite', () => {
 
-	beforeEach(() => {
-		translate.mockClear()
+        beforeEach(() => {
+                translate.mockClear()
 
-		translate
-			.mockImplementation((app, str) => str)
-	})
+                translate
+                        .mockImplementation((app, str, params = {}) => str
+                                .replace('{number}', params.number ?? '{number}')
+                                .replace('{year}', params.year ?? '{year}'))
+        })
 
-	it('should provide a format for day view', () => {
-		const date = new Date(2019, 0, 1, 0, 0, 0, 0)
-		expect(dateRangeFormat(date, 'timeGridDay', 'de')).toMatchSnapshot()
-	})
+        it('should provide a format for day view', () => {
+                const date = new Date(2019, 0, 1, 0, 0, 0, 0)
+                expect(dateRangeFormat(date, 'timeGridDay', 'de')).toMatchSnapshot()
+        })
 
-	it('should provide a format for week view', () => {
+        it('should provide a Jalali format for day view when locale is Persian', () => {
+                const date = new Date(2019, 0, 1, 0, 0, 0, 0)
+                expect(dateRangeFormat(date, 'timeGridDay', 'fa')).toMatchSnapshot()
+        })
 
-		const date = new Date(2019, 0, 1, 0, 0, 0, 0)
-		expect(dateRangeFormat(date, 'timeGridWeek', 'de')).toMatchSnapshot()
-	})
+        it('should provide a format for week view', () => {
 
-	it('should provide a format for month view', () => {
-		const date = new Date(2019, 0, 1, 0, 0, 0, 0)
-		expect(dateRangeFormat(date, 'dayGridMonth', 'de')).toMatchSnapshot()
-	})
+                const date = new Date(2019, 0, 1, 0, 0, 0, 0)
+                expect(dateRangeFormat(date, 'timeGridWeek', 'de')).toMatchSnapshot()
+        })
 
-	it('should provide month as fallback for unknown view', () => {
-		const date = new Date(2019, 0, 1, 0, 0, 0, 0)
-		expect(dateRangeFormat(date, 'fooBarUnknownView', 'de')).toMatchSnapshot()
-	})
+        it('should provide a Jalali format for week view when locale is Persian', () => {
+
+                const date = new Date(2019, 0, 1, 0, 0, 0, 0)
+                expect(dateRangeFormat(date, 'timeGridWeek', 'fa')).toMatchSnapshot()
+        })
+
+        it('should provide a format for month view', () => {
+                const date = new Date(2019, 0, 1, 0, 0, 0, 0)
+                expect(dateRangeFormat(date, 'dayGridMonth', 'de')).toMatchSnapshot()
+        })
+
+        it('should provide a Jalali format for month view when locale is Persian', () => {
+                const date = new Date(2019, 0, 1, 0, 0, 0, 0)
+                expect(dateRangeFormat(date, 'dayGridMonth', 'fa')).toMatchSnapshot()
+        })
+
+        it('should provide month as fallback for unknown view', () => {
+                const date = new Date(2019, 0, 1, 0, 0, 0, 0)
+                expect(dateRangeFormat(date, 'fooBarUnknownView', 'de')).toMatchSnapshot()
+        })
+
+        it('should provide Jalali month as fallback for unknown view when locale is Persian', () => {
+                const date = new Date(2019, 0, 1, 0, 0, 0, 0)
+                expect(dateRangeFormat(date, 'fooBarUnknownView', 'fa')).toMatchSnapshot()
+        })
 
 })

--- a/tests/javascript/unit/fullcalendar/localization/momentPlugin.test.js
+++ b/tests/javascript/unit/fullcalendar/localization/momentPlugin.test.js
@@ -1,0 +1,66 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import moment from '@nextcloud/moment'
+import { createPinia, setActivePinia } from 'pinia'
+
+import { cmdFormatter } from '../../../../../src/fullcalendar/localization/momentPlugin.js'
+import useSettingsStore from '../../../../../src/store/settings.js'
+
+jest.mock('@fullcalendar/core', () => ({
+        createPlugin: jest.fn(() => ({})),
+}))
+
+describe('fullcalendar/localization/momentPlugin', () => {
+        beforeEach(() => {
+                setActivePinia(createPinia())
+        })
+
+        const buildArgs = ({ startArray, endArray = undefined, separator = ' - ' }) => {
+                const arg = {
+                        start: { array: startArray },
+                        defaultSeparator: separator,
+                }
+
+                if (endArray) {
+                        arg.end = { array: endArray }
+                }
+
+                return arg
+        }
+
+        it('formats single Persian values with Jalali calendar tokens', () => {
+                const settingsStore = useSettingsStore()
+                settingsStore.momentLocale = 'fa-IR'
+
+                const arg = buildArgs({ startArray: [2024, 0, 15, 10, 30] })
+
+                expect(cmdFormatter('LT', arg)).toBe('۱۰:۳۰')
+                expect(cmdFormatter('ll', arg)).toBe('۲۵ دی ۱۴۰۲')
+                expect(cmdFormatter('ddd l', arg)).toBe('دوشنبه ۱۴۰۲/۱۰/۲۵')
+                expect(cmdFormatter('LL, dddd', arg)).toBe('۲۵ دی ۱۴۰۲، دوشنبه')
+        })
+
+        it('formats Persian ranges with localized separators', () => {
+                const settingsStore = useSettingsStore()
+                settingsStore.momentLocale = 'fa'
+
+                const arg = buildArgs({
+                        startArray: [2024, 0, 15, 10, 30],
+                        endArray: [2024, 0, 15, 12, 0],
+                })
+
+                expect(cmdFormatter('LT', arg)).toBe('۱۰:۳۰ - ۱۲:۰۰')
+        })
+
+        it('falls back to moment for non-Persian locales', () => {
+                const settingsStore = useSettingsStore()
+                settingsStore.momentLocale = 'en'
+
+                const arg = buildArgs({ startArray: [2024, 0, 15, 10, 30] })
+                const expected = moment([2024, 0, 15, 10, 30]).locale('en').format('LT')
+
+                expect(cmdFormatter('LT', arg)).toBe(expected)
+        })
+})


### PR DESCRIPTION
## Summary
- extend the Jalali utilities with reusable numeric, short-date, weekday, and time formatters
- localize FullCalendar's moment plugin for Persian locales while preserving the existing moment-based fallback
- add unit coverage that exercises Jalali formatting and range handling for the moment plugin
- localize the alarm formatter to output Jalali times and long dates for Persian locales and assert the new behavior in unit tests

## Testing
- npm test -- momentPlugin.test.js --coverage=false
- npm test -- dateFormat.test.js --coverage=false
- npm test -- dateRangeFormat.test.js --coverage=false
- npm test -- alarmFormat.test.js --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68ce9f6a8294832ca2d7af5be6e57499